### PR TITLE
feat: add link for nuxt starter

### DIFF
--- a/Supported_frameworks.md
+++ b/Supported_frameworks.md
@@ -4,6 +4,7 @@ The following is a list of frameworks that we have actively tested and are suppo
 
 - [Next.js](https://stackblitz.com/fork/nextjs)
 - [NestJS](https://stackblitz.com/fork/nestjs-starter)
+- [Nuxt](https://stackblitz.com/fork/nuxt-starter)
 
 ## Add support for a framework
 

--- a/Supported_frameworks.md
+++ b/Supported_frameworks.md
@@ -4,7 +4,7 @@ The following is a list of frameworks that we have actively tested and are suppo
 
 - [Next.js](https://stackblitz.com/fork/nextjs)
 - [NestJS](https://stackblitz.com/fork/nestjs-starter)
-- [Nuxt](https://stackblitz.com/fork/nuxt-starter)
+- [Nuxt](https://stackblitz.com/github/nuxt/starter/tree/stackblitz)
 
 ## Add support for a framework
 


### PR DESCRIPTION
This adds a link to the Nuxt starter repo. I've used a `/fork` link given your changes in https://github.com/stackblitz/webcontainer-core/pull/37, but it would be nice to keep it up-to-date with the GitHub repo it comes from if possible (https://github.com/nuxt/starter).

A URL like https://stackblitz.com/fork/github/nuxt/starter perhaps?