### PR TITLE
docs: add Egg.js showcase

### DIFF
--- a/Supported_frameworks.md
+++ b/Supported_frameworks.md
@@ -7,6 +7,7 @@ The following is a list of frameworks that we have actively tested and are suppo
 - [NestJS](https://stackblitz.com/fork/nestjs-starter)
 - [Next.js](https://stackblitz.com/fork/nextjs)
 - [Nuxt](https://stackblitz.com/github/nuxt/starter/tree/stackblitz)
+- [Egg.js](https://stackblitz.com/edit/webcontainer-egg?file=README.md)
 
 ## Add support for a framework
 


### PR DESCRIPTION
Egg.js is an framework for building better enterprise frameworks and apps with Node.js.

It's  opensource by Alibaba, and widely used at China.