### PR TITLE
Add `retes` to `Supported_frameworks.md`

### DIFF
--- a/Supported_frameworks.md
+++ b/Supported_frameworks.md
@@ -8,6 +8,7 @@ The following is a list of frameworks that we have actively tested and are suppo
 - [Next.js](https://stackblitz.com/fork/nextjs)
 - [Nuxt](https://stackblitz.com/github/nuxt/starter/tree/stackblitz)
 - [Egg.js](https://stackblitz.com/edit/webcontainer-egg?file=README.md)
+- [Retes](https://stackblitz.com/edit/retes)
 
 ## Add support for a framework
 


### PR DESCRIPTION
[Retes](https://github.com/kreteshq/retes) is a typed, declarative, data-driven routing for Node.js.