### PR TITLE
docs: added link to changelog

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,3 +23,7 @@ For documentation, visit **[webcontainers.io](https://webcontainers.io)** where 
 
 - Chat with our team on [Discord](https://discord.gg/stackblitz)
 - For Enterprise inquiries, visit [Enterprise](https://webcontainers.io/enterprise)
+
+## Changelog
+
+The changelog is made available [in our documentation](https://webcontainers.io/changelog).


### PR DESCRIPTION
I took me some time to find what was new between 1.0 and 1.1.

I usually expect a changelog in the pages listed here: 

![image](https://user-images.githubusercontent.com/48261497/233935268-01051672-c7b5-47c8-859d-1453efb4a583.png)
